### PR TITLE
銃撃モードバグ修正

### DIFF
--- a/GameTemplate/Game/Player.cpp
+++ b/GameTemplate/Game/Player.cpp
@@ -251,6 +251,9 @@ void Player::PlayAnimation()
 		//攻撃
 		m_modelRender.PlayAnimation(enAnimationClip_Gunshot, 0.1f);
 		break;
+	case Player::enPlayerState_PostureWalk:
+		m_modelRender.PlayAnimation(enAnimationClip_Idle, 0.1f);
+		break;
 	}
 }
 


### PR DESCRIPTION
銃撃モードで一発しか弾が打てないバグ修正
銃撃モードで弾を撃ってないときのアニメーションが無くて、結果的にアタックモーションが再生しなおしが発生しないのが原因