### PR TITLE
ゲームクリアの際にイベントムービーを割り込めるように変更

### DIFF
--- a/GameTemplate/Game/Game.h
+++ b/GameTemplate/Game/Game.h
@@ -32,7 +32,8 @@ public:
 	enum EnGameState {
 		enIdle,
 		enGameClear,
-		enGameOver
+		enGameOver,
+		enEvent
 	};
 
 	//エネミーの攻撃可能ポイント
@@ -129,6 +130,7 @@ private:
 
 	PreSpriteRender m_preSpriteRender;
 	EnGameState m_gameState = enIdle;
+	EnGameState m_EventAfterState;	//イベントシーン終了後に移行するステート
 
 	bool m_enemyAllKillFlag = false;	//敵を全滅させたか
 };

--- a/GameTemplate/Game/GameTimer.cpp
+++ b/GameTemplate/Game/GameTimer.cpp
@@ -60,6 +60,12 @@ void GameTimer::FontDraw()
 void GameTimer::Render(RenderContext& rc)
 {
 	m_game = FindGO<Game>("game");
+
+	//ゲームオブジェクトが見つからなければ処理を飛ばす
+	if (m_game == nullptr)
+	{
+		return;
+	}
 	if (m_game->m_TempDelGameTimer == true) {
 		m_spriteRender.Draw(rc);
 	}

--- a/GameTemplate/Game/Player.cpp
+++ b/GameTemplate/Game/Player.cpp
@@ -12,7 +12,7 @@ Player::Player()
 
 Player::~Player()
 {
-
+	DeleteGO(m_collisionObject);
 }
 
 bool Player::Start()
@@ -474,6 +474,9 @@ void Player::TimeAdjustment()
 
 void Player::Render(RenderContext& rc)
 {
+	if (m_game->m_TempDelPlayer == false)
+	{
 		//モデルの描画。
 		m_modelRender.Draw(rc);
+	}
 }


### PR DESCRIPTION
ゲームのステートにenEventを追加、
ついでに
プレイヤーのコリジョンの削除し忘れ
gameTimerの削除処理がgameクラスにもgameClearクラスにも書かれていたり、なにかと怪しかったので修正