### PR TITLE
ローリング更新

### DIFF
--- a/GameTemplate/Game/Player.cpp
+++ b/GameTemplate/Game/Player.cpp
@@ -165,6 +165,9 @@ void Player::Rolling()
 	//ちょっとだけモデルの座標を挙げる。
 	modelPosition.y += 2.5f;
 	m_modelRender.SetPosition(modelPosition);
+
+	m_forward = Vector3::AxisZ;
+	m_rotation.Apply(m_forward);
 }
 
 void Player::Rotation()


### PR DESCRIPTION
銃を構えた状態でローロングをした際、プレイヤーの正面ベクトルを記録する変数の更新処理の入れ忘れを修正