### PR TITLE
ゲームタイマーのUIの描画順を微調整、タイトルのエフェクトを調整

### DIFF
--- a/GameTemplate/Game/Assets/shader/sprite_Title.fx
+++ b/GameTemplate/Game/Assets/shader/sprite_Title.fx
@@ -37,7 +37,7 @@ float4 PSMain( PSInput In ) : SV_Target0
 {
     float4 colorTex = colorTexture.Sample(Sampler, In.uv);
 	
-    colorTex.a = alphaAdd;
+    colorTex.a *= alphaAdd;
 	
     return colorTex * mulColor;
 }

--- a/GameTemplate/Game/GameTimer.cpp
+++ b/GameTemplate/Game/GameTimer.cpp
@@ -15,6 +15,8 @@ GameTimer::~GameTimer()
 
 bool GameTimer::Start()
 {
+	m_game = FindGO<Game>("game");
+
 	//スプライトレンダー設定
 	m_spriteRender.Init("Assets/modelData/maintimer/maintimer.DDS", 250.0f, 100.0f);
 	//スプライトレンダーの位置を設定
@@ -48,19 +50,29 @@ void GameTimer::IncreaseTimer()
 	m_minit += g_gameTime->GetFrameDeltaTime();	// 1f=1/60秒
 }
 
-void GameTimer::FontDraw()
+void GameTimer::FontSet()
 {
-		wchar_t wcsbuf[256];
-		swprintf_s(wcsbuf, 256, L"%02d:%02d", int(m_timer), int(m_minit));
+	wchar_t wcsbuf[256];
+	//制限時間を表示
+	swprintf_s(wcsbuf, 256, L"%02d:%02d", int(m_timer), int(m_minit));
+	//表示するテキストを設定
+	m_fontRender.SetText(wcsbuf);
+	//フォントの位置を設定
+	m_fontRender.SetPosition(Vector3(-900.0f, -400.0f, 0.0f));
+	//フォントの大きさを設定
+	m_fontRender.SetScale(2.0f);
+	//フォントの色を設定
+	m_fontRender.SetColor({ 1.0f,0.0f,0.0f,1.0f });
 
-		//表示するテキストを設定。
-		m_fontRender.SetText(wcsbuf);
+		//wchar_t wcsbuf[256];
+		//swprintf_s(wcsbuf, 256, L"%02d:%02d", int(m_timer), int(m_minit));
+
+		////表示するテキストを設定。
+		//m_fontRender.SetText(wcsbuf);
 }
 
 void GameTimer::Render(RenderContext& rc)
 {
-	m_game = FindGO<Game>("game");
-
 	//ゲームオブジェクトが見つからなければ処理を飛ばす
 	if (m_game == nullptr)
 	{
@@ -68,5 +80,6 @@ void GameTimer::Render(RenderContext& rc)
 	}
 	if (m_game->m_TempDelGameTimer == true) {
 		m_spriteRender.Draw(rc);
+		m_fontRender.Draw(rc);
 	}
 }

--- a/GameTemplate/Game/GameTimer.h
+++ b/GameTemplate/Game/GameTimer.h
@@ -14,7 +14,7 @@ public:
 	//ƒ^ƒCƒ€Œo‰ßˆ—
 	void IncreaseTimer();
 	//
-	void FontDraw();
+	void FontSet();
 	//•`‰æˆ—
 	void Render(RenderContext& rc);
 


### PR DESCRIPTION
プレイヤーのHPがピンチ時にエフェクト出現時に、UIと重なるため、ゲームタイマーの描画順を手前に変更した
タイトルの PRESS START BUTTON の周りにあった黒の描画を消した