### PR TITLE
リザルトのフォントの大きさを調整

### DIFF
--- a/GameTemplate/Game/GameClear.cpp
+++ b/GameTemplate/Game/GameClear.cpp
@@ -110,7 +110,7 @@ void GameClear::DisplayTime()
 	//フォントの位置を設定
 	m_fontRender.SetPosition(Vector3(100.0f, -300.0f, 0.0f));
 	//フォントの大きさを設定
-	m_fontRender.SetScale(2.0f);
+	m_fontRender.SetScale(1.0f);
 	//フォントの色を設定
 	m_fontRender.SetColor({ 1.0f,0.843f,0.0f,1.0f});
 	


### PR DESCRIPTION
ゲームクリア時のリザルト画面で、フォントが画面外にはみ出ていたため、フォントの大きさを調整した